### PR TITLE
Update board information

### DIFF
--- a/components/TheMenu.vue
+++ b/components/TheMenu.vue
@@ -125,7 +125,7 @@ export default {
         },
         {
           name: "Board",
-          href: "/board_recruiting",
+          href: "/board",
         },
         {
           name: "Code of Conduct",

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -4,12 +4,12 @@
     <nuxt class="mb-auto pt-24 pb-4" />
     <the-footer />
     <banner
-      v-if="showBoardBanner"
-      name="BoardBanner"
-      message="We're recruiting for the 2021-24 board! Find out more!"
-      shortMsg="We're recuiting for our board"
-      link="/board_recruiting"
-      buttonText="Learn More & Apply"
+      v-if="showBanner"
+      :name="bannerName"
+      message=""
+      shortMsg=""
+      link=""
+      buttonText="Click Here"
     />
   </div>
 </template>
@@ -27,12 +27,14 @@ export default {
   },
   data: function () {
     return {
-      showBoardBanner: null,
+      showBanner: false,
+      bannerName: "announcement-banner",
     };
   },
   mounted: function () {
-    this.showBoardBanner =
-      window.sessionStorage.getItem("BoardBanner") !== "false";
+    // uncomment to show banner on load
+    // this.showBanner =
+    //   window.sessionStorage.getItem(this.bannerName) !== "false";
   },
 };
 </script>

--- a/pages/board.vue
+++ b/pages/board.vue
@@ -48,7 +48,7 @@
                     <li>Mandy Meindersma</li>
                     <li>Mark Bennett</li>
                 </ul>
-                <p class="pt-2">The positions to be filled by each new board will be confirmed at a later date.</p>
+                <p class="pt-2">The positions to be filled by each new board member will be confirmed at a later date.</p>
             </li>
         </ol>
     </div>

--- a/pages/board.vue
+++ b/pages/board.vue
@@ -1,0 +1,59 @@
+<template>
+    <div class="max-w-7xl mx-auto spx-6 px-6 lg:px-8">
+        <h1 class="text-2xl font-bold py-4">Dev Edmonton Society Board</h1>
+        <ol>
+            <li>
+                <h2 class="text-xl font-bold py-2 border-b border-lightgrey">
+                    Board Compostion
+                </h2>
+                <p class="py-2">
+                    The Dev Edmonton Board consists of 7 members filling three
+                    year terms. Every year at the Annual General Meeting (AGM)
+                    elections will be held for any open positions. Details on
+                    how to apply and other information regarding the open roles
+                    will be posted on our
+                    <NuxtLink to="/board_recruiting" class="text-brand-primary"
+                        >board recruitment page</NuxtLink
+                    >
+                    prior to the AGM.
+                </p>
+                <p>
+                    Dev Edmonton Society desires to build a board with diverse
+                    perspectives that reflect our community.
+                </p>
+                <div class="py-2">
+                    <span><strong>Roles</strong></span>
+                    <ul class="list-disc">
+                        <li>President</li>
+                        <li>Secretary</li>
+                        <li>Treasurer</li>
+                        <li>Member at large</li>
+                    </ul>
+                </div>
+            </li>
+            <li>
+                <h2 class="text-xl font-bold py-2 border-b border-lightgrey">
+                    Current Board
+                </h2>
+                <p class="py-2">
+                    A new board was elected at the society’s AGM on January 23<sup>rd</sup>
+                    2021. The following members were elected to the board.
+                </p>
+                <ul class="list-disc">
+                    <li>Abram Hindle</li>
+                    <li>Alyssa Diehl</li>
+                    <li>Celia Nicholls</li>
+                    <li>Ian Phillipchuk</li>
+                    <li>Lauren Briske</li>
+                    <li>Mandy Meindersma</li>
+                    <li>Mark Bennett</li>
+                </ul>
+                <p class="pt-2">The positions to be filled by each new board will be confirmed at a later date.</p>
+            </li>
+        </ol>
+    </div>
+</template>
+
+<script></script>
+
+<style lang="scss" scoped></style>

--- a/pages/board_recruiting.vue
+++ b/pages/board_recruiting.vue
@@ -1,13 +1,11 @@
 <template>
     <div class="max-w-7xl mx-auto spx-6 px-6 lg:px-8">
         <h1 class="text-2xl font-bold py-4">Board Recruiting</h1>
-        <div class="flex justify-center">
-            <p>
-                There are currently no open board positions. Open positions will
-                be posted here in the months preceding the society’s Annual
-                General Meeting.
-            </p>
-        </div>
+        <p>
+            There are currently no open board positions. Open positions will be
+            posted here in the months preceding the society’s Annual General
+            Meeting.
+        </p>
         <ol>
             <li>
                 <h2 class="text-xl font-bold py-2 border-b border-lightgrey">

--- a/pages/board_recruiting.vue
+++ b/pages/board_recruiting.vue
@@ -1,12 +1,12 @@
 <template>
     <div class="max-w-7xl mx-auto spx-6 px-6 lg:px-8">
         <h1 class="text-2xl font-bold py-4">Board Recruiting</h1>
-        <div class="flex justify-center mt-4">
-            <a
-                href="https://docs.google.com/forms/d/e/1FAIpQLSclnp_-xoIeedDxn4I8w23a8NQVlQOriEVjTBFDmt5DB_DXeg/viewform?usp=sf_link"
-            >
-                <v-Button appearance="inverted">Apply Now</v-Button>
-            </a>
+        <div class="flex justify-center">
+            <p>
+                There are currently no open board positions. Open positions will
+                be posted here in the months preceding the society’s Annual
+                General Meeting.
+            </p>
         </div>
         <ol>
             <li>
@@ -16,9 +16,9 @@
                 <p class="py-2">
                     The Dev Edmonton Board consists of 7 members filling three
                     year terms. Every year at the annual meeting elections will
-                    be held for any open positions. Dev Edmonton Society
-                    desires to build a board with diverse perspectives
-                    that reflect our community.
+                    be held for any open positions. Dev Edmonton Society desires
+                    to build a board with diverse perspectives that reflect our
+                    community.
                 </p>
                 <div class="py-2">
                     <span><strong>Roles</strong></span>
@@ -51,7 +51,7 @@
                     Key Compentencies
                 </h2>
                 <p class="py-2">
-                    DES is looking to build a board that, as a collective body,
+                    DES looks to build a board that, as a collective body,
                     excercises essential competencies. We have identified the
                     following compentencies that the board needs to possess.
                 </p>
@@ -96,7 +96,9 @@
                         <li>3 Year commitment</li>
                     </ul>
                 </div>
-                <h3 class="text-lg font-bold py-1 border-b border-lightgrey">President</h3>
+                <h3 class="text-lg font-bold py-1 border-b border-lightgrey">
+                    President
+                </h3>
                 <div class="py-2">
                     <ul class="list-disc">
                         <li>Member of the Board</li>
@@ -116,7 +118,9 @@
                         <li>Steer the strategic and organizational planning</li>
                     </ul>
                 </div>
-                <h3 class="text-lg font-bold py-1 border-b border-lightgrey">Secretary</h3>
+                <h3 class="text-lg font-bold py-1 border-b border-lightgrey">
+                    Secretary
+                </h3>
                 <div class="py-2">
                     <ul class="list-disc">
                         <li>Member of the board</li>
@@ -132,7 +136,9 @@
                         </li>
                     </ul>
                 </div>
-                <h3 class="text-lg font-bold py-1 border-b border-lightgrey">Treasurer</h3>
+                <h3 class="text-lg font-bold py-1 border-b border-lightgrey">
+                    Treasurer
+                </h3>
                 <div class="py-2">
                     <ul class="list-disc">
                         <li>Member of the board</li>
@@ -145,45 +151,28 @@
                         </li>
                     </ul>
                 </div>
-                <h3 class="text-lg font-bold py-1 border-b border-lightgrey">Community Director</h3>
+                <h3 class="text-lg font-bold py-1 border-b border-lightgrey">
+                    Community Director
+                </h3>
                 <div class="py-2">
                     <ul class="list-disc">
                         <li>Member of the board</li>
-                        <li>Coordinates community and student outreach activities</li>
+                        <li>
+                            Coordinates community and student outreach
+                            activities
+                        </li>
                         <li>Manages DES social media accounts</li>
-                        <li>Provides marketing copy and resources for DES community to share</li>
+                        <li>
+                            Provides marketing copy and resources for DES
+                            community to share
+                        </li>
                     </ul>
-                </div>
-            </li>
-            <li>
-                <h2 class="text-xl font-bold py-2 border-b border-lightgrey">
-                    Apply Today!
-                </h2>
-                <p class="py-2">
-                    If you are interested in joining the board please let us
-                    know by filling out this form, and don't forget to stop by
-                    the dev edmonton slack channel and say hi!
-                </p>
-                <div class="flex justify-center mt-4">
-                    <a
-                        href="https://docs.google.com/forms/d/e/1FAIpQLSclnp_-xoIeedDxn4I8w23a8NQVlQOriEVjTBFDmt5DB_DXeg/viewform?usp=sf_link"
-                    >
-                        <v-Button appearance="inverted">Apply Now</v-Button>
-                    </a>
                 </div>
             </li>
         </ol>
     </div>
 </template>
 
-<script>
-import VButton from "~/components/VButton.vue";
-
-export default {
-    components: {
-        VButton,
-    },
-};
-</script>
+<script></script>
 
 <style lang="scss" scoped></style>


### PR DESCRIPTION
This PR can be a starting point for starting to update our board and member information on the website. It's pretty bare bones for now, but this should accomplish a few things:

- Removing the recruitment banner and links as they are no longer needed
- Adds a new page where we can put information on our current board, more content such as profiles and roles can be added to this page

Related to issue #64