### PR TITLE
Update links to Slack invite

### DIFF
--- a/components/EventsSection.vue
+++ b/components/EventsSection.vue
@@ -50,9 +50,11 @@ export default {
             coffee: {
                 name: "Random Coffees",
                 logo: require("../assets/logos/coffee-192px.png"),
-                linkTo: "https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw",
+                linkTo:
+                    "https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw",
                 slack: "#random_coffees",
-                slackLink: "https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw",
+                slackLink:
+                    "https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw",
                 durationInfo: "Duration: Ongoing (weekly)",
             },
         },

--- a/components/EventsSection.vue
+++ b/components/EventsSection.vue
@@ -50,9 +50,9 @@ export default {
             coffee: {
                 name: "Random Coffees",
                 logo: require("../assets/logos/coffee-192px.png"),
-                linkTo: "https://devedmonton-invite.herokuapp.com/",
+                linkTo: "https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw",
                 slack: "#random_coffees",
-                slackLink: "https://devedmonton-invite.herokuapp.com/",
+                slackLink: "https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw",
                 durationInfo: "Duration: Ongoing (weekly)",
             },
         },

--- a/components/EventsSection.vue
+++ b/components/EventsSection.vue
@@ -51,10 +51,10 @@ export default {
                 name: "Random Coffees",
                 logo: require("../assets/logos/coffee-192px.png"),
                 linkTo:
-                    "https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw",
+                    "https://join.slack.com/t/devedmonton/shared_invite/zt-1hqylgb8i-pKr5nUmRwOJwdLHVce0rXg",
                 slack: "#random_coffees",
                 slackLink:
-                    "https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw",
+                    "https://join.slack.com/t/devedmonton/shared_invite/zt-1hqylgb8i-pKr5nUmRwOJwdLHVce0rXg",
                 durationInfo: "Duration: Ongoing (weekly)",
             },
         },

--- a/components/SlackSection.vue
+++ b/components/SlackSection.vue
@@ -65,7 +65,7 @@
                                 >
                                     <p class="text-xl text-brand-primary">
                                         <a
-                                            href="https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw/"
+                                            href="https://join.slack.com/t/devedmonton/shared_invite/zt-1hqylgb8i-pKr5nUmRwOJwdLHVce0rXg"
                                         >
                                             Join our community on Slack
                                         </a>
@@ -76,7 +76,7 @@
                                         alt="slack logo"
                                     />
                                     <a
-                                        href="https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw"
+                                        href="https://join.slack.com/t/devedmonton/shared_invite/zt-1hqylgb8i-pKr5nUmRwOJwdLHVce0rXg"
                                     >
                                         <VButton appearance="inverted"
                                             >Join the Slack</VButton

--- a/components/SlackSection.vue
+++ b/components/SlackSection.vue
@@ -82,6 +82,20 @@
                                             >Join the Slack</VButton
                                         >
                                     </a>
+
+                                    <p
+                                        class="text-gray-500 italic font-bold p-4"
+                                    >
+                                        If you get an "invalid link" error our
+                                        Slack invite link has expired. Please
+                                        email
+                                        <a
+                                            href="mailto:board@devedmonton.com?subject=Your Slack Invite link is broken!&body=Heads up that someone needs to contact Slack support for a fresh one. ~ A friendly DES member."
+                                            class="text-brand-primary"
+                                            >board@devedmonton.com</a
+                                        >
+                                        and let us know!
+                                    </p>
                                 </div>
                             </div>
                         </div>

--- a/components/SlackSection.vue
+++ b/components/SlackSection.vue
@@ -65,7 +65,7 @@
                                 >
                                     <p class="text-xl text-brand-primary">
                                         <a
-                                            href="https://devedmonton-invite.herokuapp.com/"
+                                            href="https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw/"
                                         >
                                             Join our community on Slack
                                         </a>
@@ -76,7 +76,7 @@
                                         alt="slack logo"
                                     />
                                     <a
-                                        href="https://devedmonton-invite.herokuapp.com/"
+                                        href="https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw"
                                     >
                                         <VButton appearance="inverted"
                                             >Join the Slack</VButton

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -239,7 +239,7 @@
                                     >
                                         <a
                                             class="text-brand-primary"
-                                            href="https://devedmonton-invite.herokuapp.com/"
+                                            href="https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw"
                                             >Get started by joining our Slack</a
                                         >
                                         and make sure to say hello in our
@@ -266,7 +266,7 @@
                                 </div>
                                 <div class="flex justify-center mt-4">
                                     <a
-                                        href="https://devedmonton-invite.herokuapp.com/"
+                                        href="https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw"
                                     >
                                         <VButton appearance="inverted"
                                             >Join Slack</VButton

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -239,7 +239,7 @@
                                     >
                                         <a
                                             class="text-brand-primary"
-                                            href="https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw"
+                                            href="https://join.slack.com/t/devedmonton/shared_invite/zt-1hqylgb8i-pKr5nUmRwOJwdLHVce0rXg"
                                             >Get started by joining our Slack</a
                                         >
                                         and make sure to say hello in our
@@ -266,7 +266,7 @@
                                 </div>
                                 <div class="flex justify-center mt-4">
                                     <a
-                                        href="https://join.slack.com/t/devedmonton/shared_invite/zt-1h0s5j0g4-ntARRvWGapJcnckM34jdZw"
+                                        href="https://join.slack.com/t/devedmonton/shared_invite/zt-1hqylgb8i-pKr5nUmRwOJwdLHVce0rXg"
                                     >
                                         <VButton appearance="inverted"
                                             >Join Slack</VButton


### PR DESCRIPTION
## Changes
* MAJOR: Drop the link to the old Slack inviter app on Heroku and use a link to the official Slack join app instead

## See Also
Closes #146 